### PR TITLE
A voice-state check; Some doc

### DIFF
--- a/src/clap-saw-demo.cpp
+++ b/src/clap-saw-demo.cpp
@@ -582,6 +582,9 @@ void ClapSawDemo::handleInboundEvent(const clap_event_header_t *evt)
         // This little lambda updates a modulation slot in a voice properly
         auto applyToVoice = [&pevt](auto &v)
         {
+            if (v.state == SawDemoVoice::OFF && v.state == SawDemoVoice::NEWLY_OFF)
+                return;
+
             auto pd = pevt->param_id;
             switch (pd)
             {

--- a/src/clap-saw-demo.h
+++ b/src/clap-saw-demo.h
@@ -117,6 +117,14 @@ struct ClapSawDemo : public clap::helpers::Plugin<clap::helpers::MisbehaviourHan
         *value = *paramToValue[paramId];
         return true;
     }
+
+    /*
+     * This converts the numerical value of the parameter to a display value for the DAW.
+     * For instance we model filter cutoff in 12-TET MIDI Note space, so the value
+     * "60" of pmCutoff shows as "261.6 hz" and "69" (concert A) as "440 hz". Similarly
+     * this is where we show our time scaling for our attack and release, filter type,
+     * and so on.
+     */
     bool paramsValueToText(clap_id paramId, double value, char *display,
                            uint32_t size) noexcept override;
 


### PR DESCRIPTION
1. Don't apply modulations to voices which are off. This should
   never happen anyway, but be defensive. See #13

2. Improve the documentation on paramToText after a question from
   a user in unfa discord