### PR TITLE
Use provided scale value for UI

### DIFF
--- a/src/clap-saw-demo-editor.h
+++ b/src/clap-saw-demo-editor.h
@@ -46,8 +46,8 @@ struct ClapSawDemoEditor : public VSTGUI::VSTGUIEditorInterface, public VSTGUI::
 
     };
 
-    void setScale(double scale);
-    inline int sc(int i) const { return int(i * uiScale); }
+    void setUIScale(double scale);
+    inline int applyUIScale(int i) const { return int(i * uiScale); }
 
     void setupUI();
     uint32_t paramIdFromTag(int32_t tag);

--- a/src/clap-saw-demo-editor.h
+++ b/src/clap-saw-demo-editor.h
@@ -25,7 +25,7 @@ struct ClapSawDemoEditor : public VSTGUI::VSTGUIEditorInterface, public VSTGUI::
 
     ClapSawDemoEditor(ClapSawDemo::SynthToUI_Queue_t &, ClapSawDemo::UIToSynth_Queue_t &,
                       const ClapSawDemo::DataCopyForUI &, std::function<void()>);
-    ~ClapSawDemoEditor();
+    ~ClapSawDemoEditor() override;
 
     void haltIdleTimer();
 
@@ -46,6 +46,9 @@ struct ClapSawDemoEditor : public VSTGUI::VSTGUIEditorInterface, public VSTGUI::
 
     };
 
+    void setScale(double scale);
+    inline int sc(int i) const { return int(i * uiScale); }
+
     void setupUI();
     uint32_t paramIdFromTag(int32_t tag);
 
@@ -55,10 +58,13 @@ struct ClapSawDemoEditor : public VSTGUI::VSTGUIEditorInterface, public VSTGUI::
     VSTGUI::CVSTGUITimer *idleTimer{nullptr};
 
   private:
+    double uiScale{1.0};
+
     uint32_t lastDataUpdate{0};
     ClapSawDemoBackground *backgroundRender{nullptr};
     // These are all weak references owned by the frame
-    VSTGUI::CTextLabel *topLabel{nullptr}, *bottomLabel{nullptr}, *statusLabel{nullptr};
+    VSTGUI::CTextLabel *topLabel{nullptr}, *repoLabel{nullptr},
+        *bottomLabel{nullptr}, *statusLabel{nullptr};
 
     VSTGUI::CTextLabel *ampLabel{nullptr};
     VSTGUI::CCheckBox *ampToggle{nullptr};

--- a/src/clap-saw-demo.h
+++ b/src/clap-saw-demo.h
@@ -243,15 +243,11 @@ struct ClapSawDemo : public clap::helpers::Plugin<clap::helpers::MisbehaviourHan
     void guiDestroy() noexcept override;
     bool guiSetParent(const clap_window *window) noexcept override;
 
+    bool guiSetScale(double scale) noexcept override;
     bool guiCanResize() const noexcept override { return true; }
     bool guiAdjustSize(uint32_t *width, uint32_t *height) noexcept override;
     bool guiSetSize(uint32_t width, uint32_t height) noexcept override;
-    bool guiGetSize(uint32_t *width, uint32_t *height) noexcept override
-    {
-        *width = GUI_DEFAULT_W;
-        *height = GUI_DEFAULT_H;
-        return true;
-    }
+    bool guiGetSize(uint32_t *width, uint32_t *height) noexcept override;
 
     // Setting this atomic to true will force a push of all current engine
     // params to ui using the queue mechanism


### PR DESCRIPTION
Within the CLAP API, there is a function that will set the absolute GUI scaling factor. This enables plugins to size themselves to the OS scale, which typically is what you would expect by default.

The changes in this PR listen to that method and adapt the building of the UI accordingly. It's not the most elegant code, but then VSTGUI isn't really set up for that anyway, and it works.

When tested on Windows, the UI will scale according to whatever the user has chosen within their OS desktop scaling.

Notably, Bitwig has a setting for each plug-in "Stretch Plug-in Window to Match DPI", but this does not have any effect and I suspect is currently just a hangover from the VST config. Ideally, this option would enable CLAP to report the bitwig scaling value from the settings (appropriately normalised) instead of that defined by the OS, and vice-versa but currently it does not seem to.