### PR TITLE
Defensively handle early guiSetSize

### DIFF
--- a/src/clap-saw-demo-editor.cpp
+++ b/src/clap-saw-demo-editor.cpp
@@ -387,6 +387,13 @@ void ClapSawDemoEditor::haltIdleTimer()
 // We add this resize method and call it from setSize to scale the background and recenter labels
 void ClapSawDemoEditor::resize()
 {
+    /*
+     * guiSetSize can be called before guiSetParent and guiSetParent is where we
+     * create our sub-components. So be defensive here.
+     */
+    if (!backgroundRender)
+        return;
+
     auto w = getFrame()->getWidth();
     auto h = getFrame()->getHeight();
     backgroundRender->setViewSize(VSTGUI::CRect(0, 0, w, h));


### PR DESCRIPTION
The gui docs are silent on whether it is valid to call
gui.set_size before gui.set_parent and REAPER 664 0802
does this. If that happens, CSD cannot respond and used to
crash. Now it rejects that setsize until set_parent has been
called