### PR TITLE
Fix Undefined Symbol for `canUsePosixFdSupportEv` on Linux Systems.

### DIFF
--- a/src/clap-saw-demo-editor.cpp
+++ b/src/clap-saw-demo-editor.cpp
@@ -10,6 +10,7 @@
 #if IS_LINUX
 #include "vstgui/lib/platform/platform_x11.h"
 #include "vstgui/lib/platform/linux/x11platform.h"
+#include "clap/helpers/host-proxy.hxx"
 #include <map>
 #include "linux-vstgui-adapter.h"
 #endif


### PR DESCRIPTION
Add missing `#include  "clap/helpers/host-proxy.hxx"` in `clap-saw-demo-editor.cpp`.

Bug: #33 