### PR TITLE
protecting against free floating hosts

### DIFF
--- a/src/clap-saw-demo.cpp
+++ b/src/clap-saw-demo.cpp
@@ -368,10 +368,12 @@ clap_process_status ClapSawDemo::process(const clap_process *process) noexcept
      * and then update transport information for the display on our
      * shared state object
      */
-    dataCopyForUI.tempo = process->transport->tempo;
-    dataCopyForUI.tsDen = process->transport->tsig_denom;
-    dataCopyForUI.tsNum = process->transport->tsig_num;
-    dataCopyForUI.songpos = 1.0 * process->transport->song_pos_beats / CLAP_BEATTIME_FACTOR;
+    if ( process->transport ) {
+      dataCopyForUI.tempo = process->transport->tempo;
+      dataCopyForUI.tsDen = process->transport->tsig_denom;
+      dataCopyForUI.tsNum = process->transport->tsig_num;
+      dataCopyForUI.songpos = 1.0 * process->transport->song_pos_beats / CLAP_BEATTIME_FACTOR;
+    }
 #endif
 
     /*

--- a/src/clap-saw-demo.cpp
+++ b/src/clap-saw-demo.cpp
@@ -368,7 +368,7 @@ clap_process_status ClapSawDemo::process(const clap_process *process) noexcept
      * and then update transport information for the display on our
      * shared state object
      */
-    if ( process->transport ) {
+    if (process->transport) {
       dataCopyForUI.tempo = process->transport->tempo;
       dataCopyForUI.tsDen = process->transport->tsig_denom;
       dataCopyForUI.tsNum = process->transport->tsig_num;

--- a/src/clap-saw-demo.cpp
+++ b/src/clap-saw-demo.cpp
@@ -368,11 +368,12 @@ clap_process_status ClapSawDemo::process(const clap_process *process) noexcept
      * and then update transport information for the display on our
      * shared state object
      */
-    if (process->transport) {
-      dataCopyForUI.tempo = process->transport->tempo;
-      dataCopyForUI.tsDen = process->transport->tsig_denom;
-      dataCopyForUI.tsNum = process->transport->tsig_num;
-      dataCopyForUI.songpos = 1.0 * process->transport->song_pos_beats / CLAP_BEATTIME_FACTOR;
+    if (process->transport)
+    {
+        dataCopyForUI.tempo = process->transport->tempo;
+        dataCopyForUI.tsDen = process->transport->tsig_denom;
+        dataCopyForUI.tsNum = process->transport->tsig_num;
+        dataCopyForUI.songpos = 1.0 * process->transport->song_pos_beats / CLAP_BEATTIME_FACTOR;
     }
 #endif
 


### PR DESCRIPTION
the `transport` pointer in the process struct is allowed to be a nullptr.
clap-saw-demo must check before reading transport information from it.